### PR TITLE
Fix Directional transition

### DIFF
--- a/Source/Transitions/MTDirectionalTransition.metal
+++ b/Source/Transitions/MTDirectionalTransition.metal
@@ -22,9 +22,8 @@ fragment float4 DirectionalFragment(VertexOut vertexIn [[ stage_in ]],
     
     float2 p = uv + progress * sign(direction);
     float2 f = fract(p);
-    return mix(getFromColor(f, fromTexture, ratio, _fromR),
-               getToColor(f, toTexture, ratio, _toR),
-               step(0.0, p.y) * step(p.y, 1.0) * step(0.0, p.x) * step(p.x, 1.0)
-               );
+    return mix(getToColor(f, toTexture, ratio, _toR),
+               getFromColor(f, fromTexture, ratio, _fromR),
+               step(0.0, p.y) * step(p.y, 1.0) * step(0.0, p.x) * step(p.x, 1.0));
 }
 


### PR DESCRIPTION
## Description

Fix directional transition.
The transition should be using next clip frame and push down the current clip frame.

## Changes

- Update `DirectionalFragment` mix function argument to match gl-transition fragment shader. 

https://gl-transitions.com/editor/Directional

<img width="628" alt="image" src="https://user-images.githubusercontent.com/122647/172969580-7a8e3b6a-ffa5-4afd-aa00-08c16df04ab1.png">


## Result

### Before
https://user-images.githubusercontent.com/122647/172969059-ba98be50-8bb5-4edb-9e38-ae3be7822484.MOV

### After 
https://user-images.githubusercontent.com/122647/172969303-4e165e8a-77f8-4062-868f-0b6ce2110a0d.mov




